### PR TITLE
instead of rx.redirect, use a normal link

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,6 @@ VOLUME $CACHE_PATH
 
 WORKDIR $WORKSPACE
 
-# this is needed to run reflex
-RUN curl -fsSL https://deb.nodesource.com/setup_14.x | bash -
-RUN apt update -y && apt install nodejs -y
-
 COPY ./service/requirements.txt ./
 
 RUN pip install -r requirements.txt 

--- a/service/app/views/home/main.py
+++ b/service/app/views/home/main.py
@@ -40,7 +40,7 @@ class HomePage(ViewInterface):
         )
 
     def make_export_button(
-        self, label_text, bg_color, on_click_event, size="sm", tag="add", is_disabled=False
+        self, label_text, bg_color, size="sm", tag="add", is_disabled=False
     ):
         """
         Makes a new reflex button
@@ -49,8 +49,12 @@ class HomePage(ViewInterface):
 
         label = rx.hstack(rx.text(label_text, as_="b"), rx.icon(tag=tag))
 
-        return rx.button(
-            label, size=size, bg=bg_color, on_click=on_click_event, is_disabled=is_disabled
+        return rx.el.a(
+            rx.button(
+                label, size=size, bg=bg_color, is_disabled=is_disabled
+            ),
+            href="http://localhost:8000/export",
+            target="_blank",
         )
     
     def make_heading_element(self, data, color="black", bg_color=None):
@@ -134,7 +138,6 @@ class HomePage(ViewInterface):
         export_button = self.make_export_button(
             "Export",
             bg_color="orange",
-            on_click_event=ExportState.download,
             tag="download",
         )
 

--- a/service/requirements.txt
+++ b/service/requirements.txt
@@ -1,3 +1,3 @@
 python-engineio>=4.6.1
 pandas
-reflex==0.2.5
+reflex==0.2.6


### PR DESCRIPTION
`rx.redirect` is only intended for internal navigation within the nextjs frontend; when you redirect to a backend url that triggers a download, it breaks the router state and the frontend app stops working.

my suggestion here is to use a normal `<a>` tag with `_target="blank"` to open the download in a separate tab and avoid disruption to the main frontend state.

perhaps this is workable for you.

my other suggestion is to remove the explicit node 14 installation to save install time (reflex requires node 18.17 anyway)